### PR TITLE
Fix typo in "introducing-community-comments" title

### DIFF
--- a/blog.json
+++ b/blog.json
@@ -50,7 +50,7 @@
     "published_at": "2019-01-26 01:00",
     "content_repository": "blog",
     "content_filepath": "posts/introducing-community-comments.md",
-    "title": "We're relaunched community comments",
+    "title": "We've relaunched community comments",
     "author_handle": "iHiD",
     "marketing_copy": "One consequence of adding mentoring to Exercism last year was the removal of casual commenting. We've now added that back. Read on to learn more."
   }


### PR DESCRIPTION
Fixes minor typo I noticed in the title of the blog post