### PR TITLE
Tweak marketing text for Grains/Bash post

### DIFF
--- a/blog.json
+++ b/blog.json
@@ -135,7 +135,7 @@
     "content_filepath": "posts/coding-intentionally-in-bash-grains.md",
     "title": "Coding Intentionally in Bash Grains",
     "author_handle": "rpalo",
-    "marketing_copy": "Often, there are many approaches that all solve the same problem.  Coming up with one that communicates your thought process and goals to others is the hard part.",
+    "marketing_copy": "Ryan Palo explores the concepts of 'intentional coding' and 'design intent' in this excellent walkthrough of the Grains exercise in Bash. Thinking of ways to solve a problem is easy- designing one that communicates your thought process and goals to others is the hard part.",
     "image_url": "https://assets.exercism.io/blog/social/coding-intentionally-in-bash-grains.png"
   }
 ]


### PR DESCRIPTION
The marketing text needs to give a quick overview to someone that stumbles across a social link to this post on a different site. I feel like the current version doesn't quite give a strong enough "what this is" to someone that's unfamiliar with the Exercism blog etc, so I've tried to add a bit to strengthen that. Once this is merged/edit-merged then we can merge the other one and deploy.