### PR TITLE
add duplicate slug script

### DIFF
--- a/bin/lint_slugs.sh
+++ b/bin/lint_slugs.sh
@@ -1,4 +1,4 @@
-function check_slugs() {
+function check_slugs {
     duplicate_slugs=$(jq -r ".[\"$1\"][].slug" config.json | sort | uniq -d)
     if [ -n "$duplicate_slugs" ]; then
         echo "\033[0;31mThe following $1 slugs are not unique:\033[0m"

--- a/bin/lint_slugs.sh
+++ b/bin/lint_slugs.sh
@@ -1,0 +1,6 @@
+duplicate_slugs=$(jq -r '.. | .slug?' config.json | sort | uniq -d)
+if [ -n "$duplicate_slugs" ]; then
+    echo "\033[0;31mThe following slugs are not unique:\033[0m"
+    echo "$duplicate_slugs"
+    exit 1
+fi

--- a/bin/lint_slugs.sh
+++ b/bin/lint_slugs.sh
@@ -1,4 +1,6 @@
-function check_slugs {
+#!/usr/bin/env bash
+
+function check_slugs() {
     duplicate_slugs=$(jq -r ".[\"$1\"][].slug" config.json | sort | uniq -d)
     if [ -n "$duplicate_slugs" ]; then
         echo "\033[0;31mThe following $1 slugs are not unique:\033[0m"

--- a/bin/lint_slugs.sh
+++ b/bin/lint_slugs.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 function check_slugs() {
-    duplicate_slugs=$(jq -r ".[\"$1\"][].slug" config.json | sort | uniq -d)
+    duplicate_slugs=$(jq -r --arg key $1 '.[$key][].slug' config.json | sort | uniq -d)
     if [ -n "$duplicate_slugs" ]; then
-        echo "\033[0;31mThe following $1 slugs are not unique:\033[0m"
+        echo -e "\033[0;31mThe following $1 slugs are not unique:\033[0m"
         echo "$duplicate_slugs"
         exit 1
     fi

--- a/bin/lint_slugs.sh
+++ b/bin/lint_slugs.sh
@@ -1,6 +1,11 @@
-duplicate_slugs=$(jq -r '.. | .slug?' config.json | sort | uniq -d)
-if [ -n "$duplicate_slugs" ]; then
-    echo "\033[0;31mThe following slugs are not unique:\033[0m"
-    echo "$duplicate_slugs"
-    exit 1
-fi
+function check_slugs() {
+    duplicate_slugs=$(jq -r ".[\"$1\"][].slug" config.json | sort | uniq -d)
+    if [ -n "$duplicate_slugs" ]; then
+        echo "\033[0;31mThe following $1 slugs are not unique:\033[0m"
+        echo "$duplicate_slugs"
+        exit 1
+    fi
+}
+
+check_slugs posts
+check_slugs stories

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
     "ajv-cli": "^5.0.0"
   },
   "scripts": {
-    "lint": "yarn lint-schema && yarn lint-uuids && yarn lint-structure && yarn lint-images",
+    "lint": "yarn lint-schema && yarn lint-uuids && yarn lint-structure && yarn lint-slugs && yarn lint-images",
     "lint-schema": "ajv validate -s config.json.schema.json -d config.json",
     "lint-uuids": "bin/lint_uuids.sh",
     "lint-structure": "bin/lint_structure.sh",
-    "lint-images": "bin/lint_images.sh"
+    "lint-images": "bin/lint_images.sh",
+    "lint-slugs": "bin/lint_slugs.sh"
   }
 }


### PR DESCRIPTION
Extra validation script to ensure all post slugs are unique.

Right now assumes all slugs must be globally unique, but it seems like `post` and `stories` could technically overlap and it'd be fine. Can tweak if that's desirable behavior.

Implementation wise, I copied the existing script but pulled the `select(. != null)` since the schema ensures everything has a slug (so there shouldn't be any nulls). 